### PR TITLE
[feat]임시비밀번호 발급 및 비밀번호 재설정 구현

### DIFF
--- a/src/main/java/wowmarket/wow_server/domain/User.java
+++ b/src/main/java/wowmarket/wow_server/domain/User.java
@@ -7,8 +7,6 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import java.io.Serializable;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -26,7 +24,6 @@ public class User extends BaseEntity implements UserDetails {
 
     private String password;
     private String name;
-    private int age;
     private String address;
     private String bank;
     private String account;
@@ -41,8 +38,9 @@ public class User extends BaseEntity implements UserDetails {
     @Enumerated(EnumType.STRING)
     private Role role;
     private String refreshToken;
+    private Boolean temporary_password;
 
-    @Enumerated
+    @Enumerated(EnumType.STRING)
     private Login_Method login_method;
 
     public void encodePassword(PasswordEncoder passwordEncoder) {
@@ -51,6 +49,9 @@ public class User extends BaseEntity implements UserDetails {
     public void updateRefreshToken(String refreshToken){
         this.refreshToken = refreshToken;
     }
+
+    // 비밀번호 변경 시 임시비밀번호인지도 확인
+    public void updatePassword(String password, Boolean temp){ this.password = password; this.temporary_password = temp; }
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         List<GrantedAuthority> auth = new ArrayList<>();
@@ -58,6 +59,10 @@ public class User extends BaseEntity implements UserDetails {
         return auth;
     }
 
+
+    /**
+     * UserDetails
+     */
     @Override
     public String getUsername() {
         return email;

--- a/src/main/java/wowmarket/wow_server/login/api/UserController.java
+++ b/src/main/java/wowmarket/wow_server/login/api/UserController.java
@@ -30,6 +30,19 @@ public class UserController {
         return ResponseEntity.ok().body(userService.signIn(request)).getBody();
     }
 
+    @PostMapping("/sendTempPw")
+    @ResponseStatus(HttpStatus.OK)
+    public void sendTempPw(String email){
+        userService.sendMailAndChangePassword(email);
+    }
+
+
+    @PostMapping("/resetPw")
+    @ResponseStatus(HttpStatus.OK)
+    public Long resetPw(@Valid @RequestBody UserSignInRequestDto request){
+        return userService.updatePassword(request.getEmail(), request.getPassword(), false);
+    }
+
     @PutMapping("/newAccess")
     public TokenResponseDto issueAccessToken(HttpServletRequest request){
         return userService.issueAccessToken(request);

--- a/src/main/java/wowmarket/wow_server/login/dto/TokenResponseDto.java
+++ b/src/main/java/wowmarket/wow_server/login/dto/TokenResponseDto.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class TokenResponseDto {
+    private Boolean temporaryPw;
     private String grantType;
     private String accessToken;
     private String refreshToken;

--- a/src/main/java/wowmarket/wow_server/login/dto/UserSignUpRequestDto.java
+++ b/src/main/java/wowmarket/wow_server/login/dto/UserSignUpRequestDto.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import wowmarket.wow_server.domain.Login_Method;
 import wowmarket.wow_server.domain.Role;
 import wowmarket.wow_server.domain.User;
 
@@ -32,6 +33,8 @@ public class UserSignUpRequestDto {
                 .name(name)
                 .marketing_agree(marketing_agree)
                 .role(Role.ROLE_USER)
+                .login_method(Login_Method.EMAIL)
+                .temporary_password(Boolean.FALSE)
                 .build();
     }
 }

--- a/src/main/java/wowmarket/wow_server/login/service/UserService.java
+++ b/src/main/java/wowmarket/wow_server/login/service/UserService.java
@@ -9,5 +9,11 @@ public interface UserService {
     public Long signUp(UserSignUpRequestDto requestDto) throws Exception;
 
     public TokenResponseDto signIn(UserSignInRequestDto requestDto) throws Exception;
+
+    public void sendMailAndChangePassword(String email);
+    public Long updatePassword(String str, String email, Boolean temp);
+    public String getTempPassword();
+
+
     public TokenResponseDto issueAccessToken(HttpServletRequest request);
 }


### PR DESCRIPTION
- 입력 받은 이메일로 임시비밀번호 전송 api 구현
- 로그인 시 입력 받은 비밀번호가 사용자가 설정한 이메일인지/ 임시 지정된 비밀번호인지 확인하는 로직 추가
  -> User entity에 temporary_password 컬럼 추가하였습니다
- 비밀번호 재설정 api 구현