### PR TITLE
[Feat] 판매 홈&검색 api 1차 구현

### DIFF
--- a/src/main/java/wowmarket/wow_server/domain/Project.java
+++ b/src/main/java/wowmarket/wow_server/domain/Project.java
@@ -47,6 +47,8 @@ public class Project extends BaseEntity{
     private int re_progress;
     private Long final_achievement_rate;
 
+    @Column(columnDefinition = "integer default 0", nullable = false)
+    private int view; //조회수
 
     public void setUser(User user){
         this.user = user;

--- a/src/main/java/wowmarket/wow_server/domain/User.java
+++ b/src/main/java/wowmarket/wow_server/domain/User.java
@@ -28,6 +28,7 @@ public class User extends BaseEntity implements UserDetails {
     private String bank;
     private String account;
     private String phone;
+    @Column(unique = true, nullable = false)
     private String email;
     private String univ;
     private LocalDateTime univ_auth;

--- a/src/main/java/wowmarket/wow_server/domain/User.java
+++ b/src/main/java/wowmarket/wow_server/domain/User.java
@@ -31,8 +31,7 @@ public class User extends BaseEntity implements UserDetails {
     private String email;
     private String univ;
     private LocalDateTime univ_auth;
-    private Boolean univ_check;
-    private Boolean is_seller;
+    private boolean univ_check;
     private Boolean marketing_agree;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/wowmarket/wow_server/repository/ItemRepository.java
+++ b/src/main/java/wowmarket/wow_server/repository/ItemRepository.java
@@ -1,7 +1,20 @@
 package wowmarket.wow_server.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import wowmarket.wow_server.domain.Item;
+import wowmarket.wow_server.domain.Project;
+
+import java.util.List;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
+    List<Item> findByProject(Project project);
+
+    @Query("SELECT SUM(i.goal) FROM Item i WHERE i.project = :project")
+    int getTotalGoalByProject(@Param("project") Project project);
+
+    @Query("SELECT SUM(od.count) FROM OrderDetail od WHERE od.item.project = :project")
+    int getTotalOrderCountByProject(@Param("project") Project project);
+    //OrderDetail이 아닌 Item에서 주문 개수를 고려하여 프로젝트 별 주문 개수의 합을 구하는 쿼리
 }

--- a/src/main/java/wowmarket/wow_server/repository/ProjectRepository.java
+++ b/src/main/java/wowmarket/wow_server/repository/ProjectRepository.java
@@ -3,6 +3,8 @@ package wowmarket.wow_server.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import wowmarket.wow_server.domain.Project;
 
-public interface ProjectRepository extends JpaRepository<Project, Long> {
+import java.util.List;
 
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+    List<Project> findByNameContaining(String name);
 }

--- a/src/main/java/wowmarket/wow_server/sale/controller/SaleHomeController.java
+++ b/src/main/java/wowmarket/wow_server/sale/controller/SaleHomeController.java
@@ -1,0 +1,26 @@
+package wowmarket.wow_server.sale.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import wowmarket.wow_server.sale.dto.SaleListResponseDto;
+import wowmarket.wow_server.sale.service.SaleHomeService;
+
+@RestController
+@RequestMapping("/wowmarket/sale")
+@RequiredArgsConstructor
+public class SaleHomeController {
+    private final SaleHomeService saleHomeService;
+
+    @GetMapping("/{user_id}") //만약 user_id를 넘겨받지 않으면 소속학교를 알 수 없음 근데 url로 받지는 않을 예정이지만 일단 이렇게 구현
+//    /wowmarket/sale/{user_id}?univ=${univ}&orderby=${orderby}&lastpostid=${lastpostid}&size=${size}
+    public SaleListResponseDto GetSaleProjectListHome(
+            @PathVariable Long user_id, //아이디가 없으면???? 로그인 하지 않은 사용자 처리????
+            @RequestParam(name = "univ", defaultValue = "myUniv", required = true) String univ, //myUniv, allUniv
+            //근데 또 로그인이 안 되어있으면 allUniv가 디폴트..!ㅠㅠㅠㅜㅠ
+            @RequestParam(name = "orderby", defaultValue = "endDate", required = true) String orderby, //endDate, popularity, createdDate
+            @RequestParam("lastpostid") Long lastpostid, //무한스크롤 구현을 위해 현재 보고 있는 상품의 마지막 id
+            @RequestParam("size") int size) { //상품 몇 개씩 보여줄지 size
+        //로그인이 되지 않은 상태면 univ = all
+        return saleHomeService.findSaleProjectHome(user_id, univ, orderby);
+    }
+}

--- a/src/main/java/wowmarket/wow_server/sale/controller/SaleSearchController.java
+++ b/src/main/java/wowmarket/wow_server/sale/controller/SaleSearchController.java
@@ -1,0 +1,23 @@
+package wowmarket.wow_server.sale.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import wowmarket.wow_server.sale.dto.SaleListResponseDto;
+import wowmarket.wow_server.sale.service.SaleSearchService;
+
+@RestController
+@RequestMapping("/wowmarket/sale")
+@RequiredArgsConstructor
+public class SaleSearchController {
+    private final SaleSearchService saleSearchService;
+
+    @GetMapping
+    public SaleListResponseDto GetSaleProjectListSearch(
+            @RequestParam("search") String search
+    ) {
+        return saleSearchService.findProjectBySearch(search);//로그인 유무와 유저 정보 필요!!
+    }
+}

--- a/src/main/java/wowmarket/wow_server/sale/dto/SaleListResponseDto.java
+++ b/src/main/java/wowmarket/wow_server/sale/dto/SaleListResponseDto.java
@@ -1,0 +1,18 @@
+package wowmarket.wow_server.sale.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class SaleListResponseDto {
+    private String univ;
+    private List<SaleResponseDto> project_list;
+
+    public SaleListResponseDto(String univ, List<SaleResponseDto> newDtos) {
+        this.univ = univ;
+        project_list = newDtos;
+    }
+}

--- a/src/main/java/wowmarket/wow_server/sale/dto/SaleResponseDto.java
+++ b/src/main/java/wowmarket/wow_server/sale/dto/SaleResponseDto.java
@@ -1,0 +1,28 @@
+package wowmarket.wow_server.sale.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wowmarket.wow_server.domain.Project;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class SaleResponseDto {
+    private String project_name;
+    private String seller_name;
+    private LocalDate start_date;
+    private LocalDate end_date;
+    //    private Blob img;
+    private int achieved; //달성률 분자: 모든 주문상세의 '주문개수' 컬럼의 합
+    private int goal; //달성률 분모: 상품 테이블에서 프로젝트 번호로 조회하여 해당 프로젝트에 들어있는 상품의 목표치의 합
+
+    public SaleResponseDto(Project project, int project_total_count, int project_total_goal) {
+        this.project_name = project.getName();
+        this.seller_name = project.getNickname();
+        this.start_date = project.getStart_date();
+        this.end_date = project.getEnd_date();
+        this.achieved = project_total_count;
+        this.goal = project_total_goal;
+    }
+}

--- a/src/main/java/wowmarket/wow_server/sale/service/SaleHomeService.java
+++ b/src/main/java/wowmarket/wow_server/sale/service/SaleHomeService.java
@@ -1,0 +1,65 @@
+package wowmarket.wow_server.sale.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import wowmarket.wow_server.domain.Project;
+import wowmarket.wow_server.domain.User;
+import wowmarket.wow_server.repository.ItemRepository;
+import wowmarket.wow_server.repository.ProjectRepository;
+import wowmarket.wow_server.repository.UserRepository;
+import wowmarket.wow_server.sale.dto.SaleListResponseDto;
+import wowmarket.wow_server.sale.dto.SaleResponseDto;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SaleHomeService {
+    private final UserRepository userRepository;
+    private final ProjectRepository projectRepository;
+    private final ItemRepository itemRepository;
+
+    public SaleListResponseDto findSaleProjectHome(Long userId, String univ, String orderby) {
+        //추후에 사용자를 어떻게 식별할 지 결정되면 코드 수정할 예정
+        User user = userRepository.findById(userId).get(); //로그인이 안 되었을 때는?!
+        String user_univ = user.getUniv();
+        List<Project> allProjects = projectRepository.findAll();
+        List<Project> univProjects = new ArrayList<>();
+        List<Project> sortedProjects = new ArrayList<>();
+
+        //사용자의 학교 인증 미완 시 학교 필터 all만 가능 myUniv 불가 -> 프론트에서 사용자애게 알려주기
+        if (univ.equals("myUniv")) {
+            //학교 필터 myUniv
+            univProjects = allProjects.stream()
+                    .filter(project -> project.getUser().getUniv().equals(user_univ))
+                    .toList();
+
+        } else { // !user.isUniv_check() || univ.equals("allUniv")
+            univProjects = allProjects;
+        }
+
+        //정렬 조건 endDate, popularity, startDate
+        if (orderby.equals("endDate")) { //default
+            sortedProjects = univProjects.stream()
+                    .sorted(Comparator.comparing(Project::getEnd_date)).toList();
+        } else if (orderby.equals("startDate")) {
+            sortedProjects = univProjects.stream()
+                    .sorted(Comparator.comparing(Project::getStart_date)).toList();
+        } else { //popularity
+            sortedProjects = univProjects.stream()
+                    .sorted(Comparator.comparing(Project::getView).reversed()).toList();
+        }
+
+        List<SaleResponseDto> saleProjectDtos = sortedProjects.stream()
+                .map(project -> new SaleResponseDto(project,
+                        itemRepository.getTotalOrderCountByProject(project),
+                        itemRepository.getTotalGoalByProject(project)))
+                .toList();
+
+        return new SaleListResponseDto(user_univ, saleProjectDtos);
+    }
+}

--- a/src/main/java/wowmarket/wow_server/sale/service/SaleSearchService.java
+++ b/src/main/java/wowmarket/wow_server/sale/service/SaleSearchService.java
@@ -1,0 +1,44 @@
+package wowmarket.wow_server.sale.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import wowmarket.wow_server.domain.Project;
+import wowmarket.wow_server.repository.ItemRepository;
+import wowmarket.wow_server.repository.ProjectRepository;
+import wowmarket.wow_server.sale.dto.SaleListResponseDto;
+import wowmarket.wow_server.sale.dto.SaleResponseDto;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SaleSearchService {
+    private final ProjectRepository projectRepository;
+    private final ItemRepository itemRepository;
+
+    public SaleListResponseDto findProjectBySearch(String search) {
+        String user_univ = "";
+        List<Project> searchProjects = projectRepository.findByNameContaining(search);
+
+        //로그인이 된 상태 : 소속학교 + 마감임박순
+        List<Project> univProjects = searchProjects.stream()
+                .filter(project -> project.getUser().getUniv().equals(user_univ))
+                .toList();
+
+        //로그인이 안 된 상태이거나 학교 인증 미완 : 전체학교 + 마감임박순
+        //univProjects = searchProjects;
+
+        List<Project> sortedProjects = univProjects.stream().sorted(Comparator.comparing(Project::getEnd_date)).toList();
+
+        List<SaleResponseDto> saleProjectDtos = sortedProjects.stream().map(project -> new SaleResponseDto(project,
+                        itemRepository.getTotalOrderCountByProject(project),
+                        itemRepository.getTotalGoalByProject(project)))
+                .toList();
+
+        return new SaleListResponseDto(user_univ, saleProjectDtos);
+
+    }
+}


### PR DESCRIPTION
2023.07.29
1. 판매 홈&검색 페이지 api 1차 구현
2. 로그인 유무 상태와 로그인 시 사용자 식별 정보 받아오는 부분 고민
    판매 홈에서는 우선 PathVariable로 받아왔고
    수정은 그렇게 어렵지 않을 거 같아서 검색에서는 일단 그냥 안 받아오고 빈 스트링으로 처리
3. 추후 조회수와 무한스크롤 로직 구현 필요 