### PR TITLE
[Feat] 학교 인증 api 1차 구현

### DIFF
--- a/src/main/java/wowmarket/wow_server/login/api/KakaoController.java
+++ b/src/main/java/wowmarket/wow_server/login/api/KakaoController.java
@@ -7,9 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import wowmarket.wow_server.login.service.KakaoAPIService;
 
-import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.Map;
 
 @Controller
 public class KakaoController {

--- a/src/main/java/wowmarket/wow_server/login/api/UnivController.java
+++ b/src/main/java/wowmarket/wow_server/login/api/UnivController.java
@@ -1,0 +1,30 @@
+package wowmarket.wow_server.login.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import wowmarket.wow_server.login.service.UnivService;
+
+
+@RestController
+@RequiredArgsConstructor
+public class UnivController {
+    private final UnivService univService;
+
+    @PostMapping("/wowmarket/users/univCert")
+    public String univCertify(@RequestParam String univ_name, @RequestParam String univ_email) {
+        System.out.println("\n===============================================\n");
+        System.out.println("[univCertify Controller] 학교 인증 시작\n");
+        return univService.univCertCertify(univ_name, univ_email);
+    }
+
+    @PostMapping("/wowmarket/users/univCert/code")
+    public String univCertifyCode(@RequestParam String univ_name,
+                                  @RequestParam String univ_email,
+                                  @RequestParam int code) {
+        System.out.println("\n[univCertify Controller] 인증 코드로 학교 인증\n");
+        return univService.univCertCertifyCode(univ_name, univ_email, code);
+    }
+
+}

--- a/src/main/java/wowmarket/wow_server/login/dto/UnivCertifyCodeRequestDto.java
+++ b/src/main/java/wowmarket/wow_server/login/dto/UnivCertifyCodeRequestDto.java
@@ -1,0 +1,21 @@
+package wowmarket.wow_server.login.dto;
+
+import com.google.gson.Gson;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UnivCertifyCodeRequestDto {
+    private String key; //univCertAPI
+    private String univName;
+    private String email; //univ_email;
+    private int code;
+
+    public String toJson() {
+        Gson gson = new Gson();
+        return gson.toJson(this);
+    }
+}

--- a/src/main/java/wowmarket/wow_server/login/dto/UnivCertifyRequestDto.java
+++ b/src/main/java/wowmarket/wow_server/login/dto/UnivCertifyRequestDto.java
@@ -1,0 +1,21 @@
+package wowmarket.wow_server.login.dto;
+
+import com.google.gson.Gson;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UnivCertifyRequestDto { //univCert로 보내는 request
+    private String key; //univCertAPI
+    private String univName;
+    private String email; //univ_email;
+    private boolean univ_check; //true : 대학 재학, false : 메일 소유
+
+    public String toJson() {
+        Gson gson = new Gson();
+        return gson.toJson(this);
+    }
+}

--- a/src/main/java/wowmarket/wow_server/login/service/KakaoAPIService.java
+++ b/src/main/java/wowmarket/wow_server/login/service/KakaoAPIService.java
@@ -15,7 +15,6 @@ import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.HashMap;
-import java.util.Optional;
 
 /**
  * 인증 코드로 Access_Token을 받아올 작업을 수행할 Service 클래스 생성

--- a/src/main/java/wowmarket/wow_server/login/service/UnivService.java
+++ b/src/main/java/wowmarket/wow_server/login/service/UnivService.java
@@ -1,0 +1,117 @@
+package wowmarket.wow_server.login.service;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import wowmarket.wow_server.login.dto.UnivCertifyCodeRequestDto;
+import wowmarket.wow_server.login.dto.UnivCertifyRequestDto;
+
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+@Service
+@RequiredArgsConstructor
+public class UnivService {
+    private final static String univCertAPI = "e8ad2247-491c-4e61-b6aa-46b3776fe7e6";
+    private final static boolean univ_check = true; //true : 대학 재학, false : 메일 소유
+
+    public String univCertCertify(String univ_name, String univ_email) {
+        String univCertifySuccess = "";
+        String reqURL = "https://univcert.com/api/v1/certify";
+
+        try {
+            URL url = new URL(reqURL);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Content-Type", "application/json"); // JSON 데이터 보내기
+            conn.setDoOutput(true);
+
+            UnivCertifyRequestDto univCertifyRequestDto = new UnivCertifyRequestDto(univCertAPI, univ_name, univ_email, univ_check);
+            String univRequestJson = univCertifyRequestDto.toJson();
+            System.out.println("[univCertCertify] univRequestJson : " + univRequestJson);
+
+            // 요청 본문을 전송하기 위한 OutputStream을 얻어옴
+            conn.setDoOutput(true);
+            OutputStream outputStream = conn.getOutputStream();
+
+            // JSON 데이터를 OutputStream을 통해 전송
+            outputStream.write(univRequestJson.getBytes("UTF-8"));
+            outputStream.flush();
+            outputStream.close();
+
+            int responseCode = conn.getResponseCode();
+            System.out.println("[univCertCertify] 상태코드 반환 : " + responseCode);
+
+            BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            String line = "";
+            String result = "";
+            while ((line = br.readLine()) != null) {
+                result += line;
+            }
+            System.out.println("[univCertCertify] response body : " + result);
+            br.close();
+
+            JsonParser parser = new JsonParser();
+            JsonElement element = parser.parse(result);
+
+            univCertifySuccess = element.getAsJsonObject().get("success").getAsString();
+            System.out.println("[univCertCertify] 인증번호 발송 성공 여부 univCertifySuccess : " + univCertifySuccess);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return univCertifySuccess;
+    }
+
+    public String univCertCertifyCode(String univ_name, String univ_email, int code) {
+        String univCertifyCodeSuccess = "";
+        String reqURL = "https://univcert.com/api/v1/certifycode";
+
+        try {
+            URL url = new URL(reqURL);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Content-Type", "application/json"); // JSON 데이터를 보내기
+            conn.setDoOutput(true);
+
+            UnivCertifyCodeRequestDto codeRequestDto = new UnivCertifyCodeRequestDto(univCertAPI, univ_name, univ_email, code);
+            String codeRequestJson = codeRequestDto.toJson();
+            System.out.println("[univCertCertifyCode] codeRequestJson : " + codeRequestJson);
+
+            // 요청 본문을 전송하기 위한 OutputStream을 얻어옴
+            conn.setDoOutput(true);
+            OutputStream outputStream = conn.getOutputStream();
+
+            // JSON 데이터를 OutputStream을 통해 전송
+            outputStream.write(codeRequestJson.getBytes("UTF-8"));
+            outputStream.flush();
+            outputStream.close();
+
+            int responseCode = conn.getResponseCode();
+            System.out.println("[univCertCertifyCode] 상태코드 반환 : " + responseCode);
+
+            BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            String line = "";
+            String result = "";
+            while ((line = br.readLine()) != null) {
+                result += line;
+            }
+            System.out.println("[univCertCertifyCode] response body : " + result);
+            br.close();
+
+            JsonParser parser = new JsonParser();
+            JsonElement element = parser.parse(result);
+
+            univCertifyCodeSuccess = element.getAsJsonObject().get("success").getAsString();
+            System.out.println("[univCertCertifyCode] 인증번호 일치 성공 여부 univCertifyCodeSuccess : " + univCertifyCodeSuccess);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return univCertifyCodeSuccess;
+    }
+}

--- a/src/main/java/wowmarket/wow_server/sale/service/SaleHomeService.java
+++ b/src/main/java/wowmarket/wow_server/sale/service/SaleHomeService.java
@@ -42,7 +42,13 @@ public class SaleHomeService {
             univProjects = allProjects;
         }
 
-        //정렬 조건 endDate, popularity, startDate
+//        아예 프론트에서 orderby를 End_date, Start_date 이렇게 넘겨주면 간단할 듯!!
+//        이렇게 사용하는 방법은 없을까?
+//        String orderMethod = "get" + orderby;
+//        sortedProjects = univProjects.stream()
+//                .sorted(Comparator.comparing(Project::orderMethod)).toList();
+
+//        //정렬 조건 endDate, popularity, startDate
         if (orderby.equals("endDate")) { //default
             sortedProjects = univProjects.stream()
                     .sorted(Comparator.comparing(Project::getEnd_date)).toList();


### PR DESCRIPTION
1. univCert 라이브러리 사용불가
2. 외부 api(univCert)와 직접 통신하도록 구현
3. 추후 사용자 식별 정보 가져오는 방법이 결정되면 user 엔티티에 학교 인증 값 설정하는 로직 필요