### PR TITLE
[Fix] 학교 인증 예외처리 & transactional 다시 반영

### DIFF
--- a/src/main/java/wowmarket/wow_server/domain/User.java
+++ b/src/main/java/wowmarket/wow_server/domain/User.java
@@ -34,7 +34,7 @@ public class User extends BaseEntity implements UserDetails {
     @Column(unique = true, nullable = false)
     private String email;
     private String univ;
-    private LocalDateTime univ_auth;
+    private String univ_certified_date;
     private boolean univ_check = false;
     private boolean marketing_agree = false;
 
@@ -46,9 +46,9 @@ public class User extends BaseEntity implements UserDetails {
     @Enumerated(EnumType.STRING)
     private Login_Method login_method;
 
-    public void updateUniv(String univ, LocalDateTime univ_auth, boolean univ_check) {
+    public void updateUniv(String univ, String univ_certified_date, boolean univ_check) {
         this.univ = univ;
-        this.univ_auth = univ_auth;
+        this.univ_certified_date = univ_certified_date;
         this.univ_check = univ_check;
     }
 

--- a/src/main/java/wowmarket/wow_server/repository/DemandItemRepository.java
+++ b/src/main/java/wowmarket/wow_server/repository/DemandItemRepository.java
@@ -13,7 +13,7 @@ public interface DemandItemRepository extends JpaRepository<DemandItem, Long> {
     @Query("SELECT SUM(di.goal) FROM DemandItem di WHERE di.demandProject = :demand_project")
     int getTotalGoalByDemandProject(@Param("demand_project") DemandProject demandProject);
 
-    @Query("SELECT SUM(dd.count) FROM DemandDetail dd WHERE dd.demand_item.demandProject = : demand_project")
+    @Query("SELECT COALESCE(SUM(dd.count), 0) FROM DemandDetail dd WHERE dd.demand_item.demandProject = :demand_project")
     int getTotalOrderCountByDemandProject(@Param("demand_project") DemandProject demandProject);
 
     List<DemandItem> findDemandItemByDemandProject_Id(Long demand_project_id);


### PR DESCRIPTION
2023.08.06 
Revert로 학교 인증 예외 처리&인증 후 도메인 변경 다시 반영
User 엔티티 LocalDateTime univ_auth에서 String univ_certified_date로 변경,  updateUniv 메소드 추가 
DemandItemRepository 충돌 해결해주시면서 수정된 쿼리 수정
